### PR TITLE
fix: error when type is module

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,4 +7,8 @@ export default defineConfig({
   splitting: true,
   clean: true,
   dts: true,
+  // Fix for https://github.com/evanw/esbuild/pull/2067
+  banner: {
+    js: "import { createRequire } from 'module'; const require = createRequire(import.meta.url);",
+  },
 })


### PR DESCRIPTION
### Description

The code packaged by fast-glob uses CommonJS to reference the path module, while tsup, which uses esbuild, replaces `require` with the `__require` shim in the generated .mjs file. When a built-in Node module is referenced, an error such as `Error: Dynamic require of 'path' is not supported` will occur. To solve this problem, you can add a banner to tsup's options, and for specific changes, please refer to File Change.

### Linked Issues

#2 

### Additional context

- https://github.com/evanw/esbuild/issues/1921
- https://github.com/evanw/esbuild/pull/2067

I'm sorry, please forgive me. 🙏
<!-- e.g. is there anything you'd like reviewers to focus on? -->
