### PR TITLE
fix: esbuild support

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@sxzz/prettier-config": "^2.0.2",
     "@types/node": "^22.8.1",
     "bumpp": "^9.7.1",
+    "esbuild": "^0.24.0",
     "eslint": "^9.13.0",
     "prettier": "^3.3.3",
     "rollup": "^4.24.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       bumpp:
         specifier: ^9.7.1
         version: 9.7.1
+      esbuild:
+        specifier: ^0.24.0
+        version: 0.24.0
       eslint:
         specifier: ^9.13.0
         version: 9.13.0(jiti@1.21.6)

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,8 +80,9 @@ export default createUnplugin<Options>((options = {}) => {
         build.onLoad(
           { filter: new RegExp(`^${ID_PREFIX}`), namespace: name },
           async ({ path }) => {
-            // eslint-disable-next-line unused-imports/no-unused-vars
-            const [_, src] = path.replace(ID_PREFIX, '').split(':', 2)
+            let [, src] = path.replace(ID_PREFIX, '').split(':', 2)
+            src = src.replaceAll(DRIVER_DIVIDER_REGEXP, ':')
+
             return {
               contents: await load(path),
               resolveDir: dirname(src),

--- a/tests/__snapshots__/resolve.test.ts.snap
+++ b/tests/__snapshots__/resolve.test.ts.snap
@@ -1,6 +1,54 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`resolve > basic 1`] = `
+exports[`resolve > EsBuild: basic 1`] = `
+"(() => {
+  // tests/fixtures/mod/a.ts
+  var a = "a";
+
+  // tests/fixtures/mod/b.ts
+  var foo = "bar";
+})();
+"
+`;
+
+exports[`resolve > EsBuild: exclude-self 1`] = `
+"(() => {
+  // tests/fixtures/mod/a.ts
+  var a = "a";
+
+  // tests/fixtures/mod/b.ts
+  var foo = "bar";
+})();
+"
+`;
+
+exports[`resolve > EsBuild: import-all 1`] = `
+"(() => {
+  // tests/fixtures/mod/a.ts
+  var a = "a";
+
+  // tests/fixtures/mod/b.ts
+  var foo = "bar";
+
+  // tests/fixtures/import-all.ts
+  console.log(a);
+  console.log(foo);
+})();
+"
+`;
+
+exports[`resolve > EsBuild: ts 1`] = `
+"(() => {
+  // tests/fixtures/mod/a.ts
+  var a = "a";
+
+  // tests/fixtures/mod/b.ts
+  var foo = "bar";
+})();
+"
+`;
+
+exports[`resolve > Rollup: basic 1`] = `
 "const a = "a";
 
 const foo = "bar";
@@ -11,7 +59,7 @@ export { a, foo };
 "
 `;
 
-exports[`resolve > exclude-self 1`] = `
+exports[`resolve > Rollup: exclude-self 1`] = `
 "const a = "a";
 
 const foo = "bar";
@@ -20,7 +68,7 @@ export { a, foo };
 "
 `;
 
-exports[`resolve > import-all 1`] = `
+exports[`resolve > Rollup: import-all 1`] = `
 "const a = "a";
 
 const foo = "bar";
@@ -32,7 +80,7 @@ export { a, foo };
 "
 `;
 
-exports[`resolve > ts 1`] = `
+exports[`resolve > Rollup: ts 1`] = `
 "const a = "a";
 
 const foo = "bar";

--- a/tests/__snapshots__/resolve.test.ts.snap
+++ b/tests/__snapshots__/resolve.test.ts.snap
@@ -1,53 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`resolve > EsBuild: basic 1`] = `
-"(() => {
-  // tests/fixtures/mod/a.ts
-  var a = "a";
-
-  // tests/fixtures/mod/b.ts
-  var foo = "bar";
-})();
-"
-`;
-
-exports[`resolve > EsBuild: exclude-self 1`] = `
-"(() => {
-  // tests/fixtures/mod/a.ts
-  var a = "a";
-
-  // tests/fixtures/mod/b.ts
-  var foo = "bar";
-})();
-"
-`;
-
-exports[`resolve > EsBuild: import-all 1`] = `
-"(() => {
-  // tests/fixtures/mod/a.ts
-  var a = "a";
-
-  // tests/fixtures/mod/b.ts
-  var foo = "bar";
-
-  // tests/fixtures/import-all.ts
-  console.log(a);
-  console.log(foo);
-})();
-"
-`;
-
-exports[`resolve > EsBuild: ts 1`] = `
-"(() => {
-  // tests/fixtures/mod/a.ts
-  var a = "a";
-
-  // tests/fixtures/mod/b.ts
-  var foo = "bar";
-})();
-"
-`;
-
 exports[`resolve > Rollup: basic 1`] = `
 "const a = "a";
 
@@ -86,5 +38,53 @@ exports[`resolve > Rollup: ts 1`] = `
 const foo = "bar";
 
 export { a, foo };
+"
+`;
+
+exports[`resolve > esbuild: basic 1`] = `
+"(() => {
+  // tests/fixtures/mod/a.ts
+  var a = "a";
+
+  // tests/fixtures/mod/b.ts
+  var foo = "bar";
+})();
+"
+`;
+
+exports[`resolve > esbuild: exclude-self 1`] = `
+"(() => {
+  // tests/fixtures/mod/a.ts
+  var a = "a";
+
+  // tests/fixtures/mod/b.ts
+  var foo = "bar";
+})();
+"
+`;
+
+exports[`resolve > esbuild: import-all 1`] = `
+"(() => {
+  // tests/fixtures/mod/a.ts
+  var a = "a";
+
+  // tests/fixtures/mod/b.ts
+  var foo = "bar";
+
+  // tests/fixtures/import-all.ts
+  console.log(a);
+  console.log(foo);
+})();
+"
+`;
+
+exports[`resolve > esbuild: ts 1`] = `
+"(() => {
+  // tests/fixtures/mod/a.ts
+  var a = "a";
+
+  // tests/fixtures/mod/b.ts
+  var foo = "bar";
+})();
 "
 `;

--- a/tests/resolve.test.ts
+++ b/tests/resolve.test.ts
@@ -1,9 +1,11 @@
 import path from 'node:path'
-import glob from 'fast-glob'
-import { rollup } from 'rollup'
-import Esbuild from 'rollup-plugin-esbuild'
 import { describe, expect, test } from 'vitest'
-import Plugin from '../src/rollup'
+import { rollup } from 'rollup'
+import { build } from 'esbuild'
+import glob from 'fast-glob'
+import Esbuild from 'rollup-plugin-esbuild'
+import RollupPlugin from '../src/rollup'
+import EsBuildPlugin from '../src/esbuild'
 
 describe('resolve', async () => {
   const fixtures = await glob(['./fixtures/*.{js,ts}', '!**/*.d.ts'], {
@@ -14,12 +16,12 @@ describe('resolve', async () => {
     const ext = path.extname(fixture)
     const filename = path.basename(fixture, ext)
 
-    test(filename, async () => {
+    test(`Rollup: ${filename}`, async () => {
       const bundle = await rollup({
         input: fixture,
         treeshake: false,
         plugins: [
-          Plugin({
+          RollupPlugin({
             dts: path.resolve(path.dirname(fixture), `${filename}-glob`),
           }),
           Esbuild(),
@@ -27,6 +29,22 @@ describe('resolve', async () => {
       })
       const { output } = await bundle.generate({})
       expect(output[0].code).toMatchSnapshot()
+    })
+
+    test(`EsBuild: ${filename}`, async () => {
+      const bundle = await build({
+        entryPoints: [fixture],
+        treeShaking: false,
+        bundle: true,
+        write: false,
+        plugins: [
+          EsBuildPlugin({
+            dts: path.resolve(path.dirname(fixture), `${filename}-glob`),
+          }) as any,
+        ],
+      })
+      const { outputFiles } = bundle
+      expect(outputFiles[0].text).toMatchSnapshot()
     })
   }
 })

--- a/tests/resolve.test.ts
+++ b/tests/resolve.test.ts
@@ -1,11 +1,11 @@
 import path from 'node:path'
-import { describe, expect, test } from 'vitest'
-import { rollup } from 'rollup'
 import { build } from 'esbuild'
 import glob from 'fast-glob'
+import { rollup } from 'rollup'
 import Esbuild from 'rollup-plugin-esbuild'
-import RollupPlugin from '../src/rollup'
+import { describe, expect, test } from 'vitest'
 import EsBuildPlugin from '../src/esbuild'
+import RollupPlugin from '../src/rollup'
 
 describe('resolve', async () => {
   const fixtures = await glob(['./fixtures/*.{js,ts}', '!**/*.d.ts'], {
@@ -31,7 +31,7 @@ describe('resolve', async () => {
       expect(output[0].code).toMatchSnapshot()
     })
 
-    test(`EsBuild: ${filename}`, async () => {
+    test(`esbuild: ${filename}`, async () => {
       const bundle = await build({
         entryPoints: [fixture],
         treeShaking: false,
@@ -40,7 +40,7 @@ describe('resolve', async () => {
         plugins: [
           EsBuildPlugin({
             dts: path.resolve(path.dirname(fixture), `${filename}-glob`),
-          }) as any,
+          }),
         ],
       })
       const { outputFiles } = bundle


### PR DESCRIPTION

### Description

当前，插件无法支持esbuild (可见单测部分，注释调插件的esbuild即可复现）

因此，我增加了esbuild 单独的插件配置，并给 resolve 返回内容增加了上下文。

当然，我也并不知道为什么会这样，可能是 unplugin 的bug? 求大佬解释下。